### PR TITLE
Fix #40 and Fix #41

### DIFF
--- a/app/assets/css/modules/create/create.css
+++ b/app/assets/css/modules/create/create.css
@@ -10,14 +10,10 @@
      If filepicker generates 3 distinct components in DOM,
      cancel out the fake ones
      ************************
-    
-    .filestack-container {
-        div:nth-child(2), div:nth-child(4) {
-            display:none;
-        }
+    */
+.filestack-container div:nth-child(2), .filestack-container div:nth-child(4) {
+  display: none; }
 
-    }
-     */
 embedly {
   transition: none; }
   embedly.ng-hide, embedly.ng-enter, embedly.ng-leave.ng-leave-active {

--- a/app/assets/css/modules/create/create.css
+++ b/app/assets/css/modules/create/create.css
@@ -10,10 +10,14 @@
      If filepicker generates 3 distinct components in DOM,
      cancel out the fake ones
      ************************
-     */
-.filestack-container div:nth-child(2), .filestack-container div:nth-child(4) {
-  display: none; }
+    
+    .filestack-container {
+        div:nth-child(2), div:nth-child(4) {
+            display:none;
+        }
 
+    }
+     */
 embedly {
   transition: none; }
   embedly.ng-hide, embedly.ng-enter, embedly.ng-leave.ng-leave-active {

--- a/app/modules/create/bindEmbedlyDirective.js
+++ b/app/modules/create/bindEmbedlyDirective.js
@@ -19,7 +19,7 @@
                 cardTitleTextSelector: 'embedly md-card-title md-card-title-text',
                 cardTitleHtml: '<md-card-title><md-card-title-text>Add title</md-card-title-text></md-card-title>',
                 cardImage: '<img class="md-card-image" ng-src="http://placehold.it/350x150" src="http://placehold.it/350x150" /> ',
-                cardImageSelector: 'embedly .md-card-image',
+                cardImageSelector: 'embedly .md-card-image.update',
                 embedlyImagesSelector: '.embedly-variation-images',
                 embedlySelector: 'embedly',
                 causeImgSelector: '.cause-img',
@@ -30,8 +30,8 @@
                 causeImg,
                 embedly,
                 embedlyImages,
-                mdCardImg,
-                causeTitle;
+                causeTitle,
+                mdCardImgs;
             scope.$on('secondstep', function () {
                 scope.cardImg = scope.$parent.cardImg;
                 scope.cardTitle = scope.$parent.cardTitle;
@@ -40,12 +40,11 @@
                 embedly = angular.element(document.querySelectorAll(params.embedlySelector)[0]);
                 embedlyImages = angular.element(document.querySelectorAll(params.embedlyImagesSelector));
                 mdCardTitleVal = angular.element(document.querySelectorAll(params.cardTitleTextSelector)[1]);
-                mdCardImg = document.querySelectorAll(params.cardImageSelector)[1];
+                mdCardImgs = document.querySelectorAll(params.cardImageSelector);
                 
                 function clickEmbedlyImageHandler() {
                     scope.$parent.cardImg = event.currentTarget.src;
-                    mdCardImg.src = event.currentTarget.src;
-                    mdCardImg.class = 'animated fadeIn';
+                    updateCardImg(event.currentTarget.src, 'animated fadeIn');
                     console.log(event.currentTarget.src);
                 }
 
@@ -69,14 +68,20 @@
                 function watchImageChange (newValue) {
                     if (newValue) {
                         scope.$parent.cardImg = newValue.trim();
-                        mdCardImg.src = newValue.trim();
-                        mdCardImg.class = 'animated fadeIn';
+                        updateCardImg(newValue.trim(), 'animated fadeIn');
                     }
+                }
+                
+                function updateCardImg (src, className) {
+                    angular.forEach(mdCardImgs, function(value, key) {
+                        mdCardImgs[key].src = src;
+                        mdCardImgs[key].class = className;
+                    });
                 }
 
                 function twoWayImg () {
-                    scope.cardImg = mdCardImg.src.toString().trim();
-                    scope.$parent.cardImg = mdCardImg.src.toString().trim();
+                    scope.cardImg = mdCardImgs[0].src.toString().trim();
+                    scope.$parent.cardImg = mdCardImgs[0].src.toString().trim();
                     scope.$watch('cardImg', watchImageChange);
 
                 }
@@ -88,11 +93,11 @@
                     mdCardTitleVal = angular.element(document.querySelectorAll(params.cardTitleTextSelector)[0]);
                     twoWayTitle();
                 }
-                if (mdCardImg) {
+                if (mdCardImgs) {
                     twoWayImg();
                 } else {
-                    embedly.prepend(params.cardImage);
-                    mdCardImg = document.querySelectorAll(params.cardImageSelector)[0];
+                    //embedly.prepend(params.cardImage);
+                    mdCardImgs = document.querySelectorAll(params.cardImageSelector);
                     twoWayImg();
                 }
             });

--- a/app/modules/create/create.html
+++ b/app/modules/create/create.html
@@ -65,7 +65,7 @@
                         <md-step-body>
                             <div layout="column" layout-gt-sm="row" layout-align="center start">
                                 <div flex="100" flex-gt-sm="50" flex-order="1" flex-order-gt-sm="0" layout-padding>
-                                    <embedly class="embedly" urlsearch="{{vm.urlSearch}}"></embedly>
+                                    <embedly updateimage="true" urlsearch="{{vm.urlSearch}}"></embedly>
                                 </div>
                                 <div flex="100" flex-gt-sm="50" flex-order="0" flex-order-gt-sm="1" layout-padding layout-margin>
                                     <span class="md-title">Customize your cause.</span>
@@ -128,11 +128,8 @@
                         <md-step-body>
                             <div layout="column" layout-gt-sm="row" layout-align="center start">
                                 <div flex="100" flex-gt-sm="50" flex-order="1" flex-order-gt-sm="0" layout-padding>
-                                    <!-- TODO: @yaboi
-                                        allow ability to update ng-src for this to work,
-                                        then add to step 2 as well instead of embedly directive
-                                    -->
-                                    <embedly hideimage="true" urlsearch="{{vm.urlSearch}}"></embedly>
+                                    <!--<embedly hideimage="true" urlsearch="{{vm.urlSearch}}"></embedly>-->
+                                    <embedly updateimage="true" urlsearch="{{vm.urlSearch}}"></embedly>
                                 </div>
                                 <div flex="100" flex-gt-sm="50" flex-order="0" flex-order-gt-sm="1" layout-padding layout-margin>
                                     <md-button flex style="width:100%" flex="100" class="md-primary md-raised md-hue-2" ng-disabled="vm.showBusyText" ng-click="vm.startCampaignFromLink()" aria-label="Create campaign now">

--- a/app/modules/create/create.html
+++ b/app/modules/create/create.html
@@ -128,7 +128,6 @@
                         <md-step-body>
                             <div layout="column" layout-gt-sm="row" layout-align="center start">
                                 <div flex="100" flex-gt-sm="50" flex-order="1" flex-order-gt-sm="0" layout-padding>
-                                    <!--<embedly hideimage="true" urlsearch="{{vm.urlSearch}}"></embedly>-->
                                     <embedly updateimage="true" urlsearch="{{vm.urlSearch}}"></embedly>
                                 </div>
                                 <div flex="100" flex-gt-sm="50" flex-order="0" flex-order-gt-sm="1" layout-padding layout-margin>

--- a/app/modules/create/create.scss
+++ b/app/modules/create/create.scss
@@ -13,14 +13,14 @@
      If filepicker generates 3 distinct components in DOM,
      cancel out the fake ones
      ************************
-    
+    */
     .filestack-container {
         div:nth-child(2), div:nth-child(4) {
             display:none;
         }
 
     }
-     */
+     
     
 embedly {
     transition: none;

--- a/app/modules/shared/directives/embedly/embedly.html
+++ b/app/modules/shared/directives/embedly/embedly.html
@@ -12,7 +12,7 @@
             </span>
         </md-card-header-text>
     </md-card-header>
-    <img ng-src="{{cardImage}}" class="md-card-image animated fadeIn" alt="{{embedCode.title}}" ng-show="embedCode.images.length > 0 && !hideimage">
+    <img ng-src="{{cardImage}}" class="md-card-image animated fadeIn" ng-class="{'update': updateimage}" alt="{{embedCode.title}}" ng-show="embedCode.images.length > 0 && !hideimage">
     <md-card-title ng-show="embedCode.title">
         <md-card-title-text>
             <span class="md-headline">{{embedCode.title}}</span>

--- a/app/modules/shared/directives/embedly/embedlyDirective.js
+++ b/app/modules/shared/directives/embedly/embedlyDirective.js
@@ -26,6 +26,7 @@
                 maxwidth: '@',
                 scheme: '@',
                 hideimage: '@',
+                updateimage: '@',
                 onempty: '&'
             },
             templateUrl: '/app/modules/shared/directives/embedly/embedly.html'
@@ -54,14 +55,14 @@
                                 switch (data.data.type) {
                                 case 'html':
                                     scope.embedCode = data.data;
-                                    if (CreateDataService.cardImage) {
-                                        scope.cardImage = CreateDataService.cardImage;
-                                        console.log('CreateDataService: ' + scope.cardImage);
-                                    } else if (!CreateDataService.cardImage && scope.embedCode.images[0].url){
+                                    // if (CreateDataService.cardImage) {
+                                    //     scope.cardImage = CreateDataService.cardImage;
+                                    //     console.log('CreateDataService: ' + scope.cardImage);
+                                    // } else if (!CreateDataService.cardImage && scope.embedCode.images[0].url){
                                         CreateDataService.cardImage = scope.embedCode.images[0].url;
                                         scope.cardImage = scope.embedCode.images[0].url;
                                         console.log('embedCode.images[0].url: ' + scope.cardImage);
-                                    }
+                                    //}
                                     break;
                                 case 'video':
                                 case 'rich':


### PR DESCRIPTION
#### What's this PR do?

Ensures the "cardImg" property is correct in step 2, 3, and campaign creation (bitly link) when an image is loaded from embedly (untouched), selected from embedly options (selected), or uploaded (filestack). 
#### Where should the reviewer start?

With an update to the [`cardImageSelector'](https://github.com/emotivhq/gs-concierge/compare/master...cardImg#diff-a53ffbea05e40842e738fcd68e1e6a48R22). It now looks for image elements with an `update` class. The [`update`](https://github.com/emotivhq/gs-concierge/compare/master...cardImg#diff-70a936639fb34a1ea9ea7ed1ac2d02c0R15) class is determined based on a directive property called [`updateimage`](https://github.com/emotivhq/gs-concierge/compare/master...cardImg#diff-d41739c769e91d8293258494aea8efccR68). These elements are updated from a [click event](https://github.com/emotivhq/gs-concierge/compare/master...cardImg#diff-a53ffbea05e40842e738fcd68e1e6a48R45) or if the image value is [updated](https://github.com/emotivhq/gs-concierge/compare/master...cardImg#diff-a53ffbea05e40842e738fcd68e1e6a48R68).
#### How should this be manually tested?
1. go to the non-profit link creator
2. Enter a url
3. Go to step 2, go to step 3, click "Create Campaign" button. Notice original image is used through process.
4. Go back to step 2, select an optional image, notice image updates in step 2, go to step 3, notice image updates in step 3, click "Create Campaign" button, notice selected image is used for campaign.
5. Go back to step 2, upload a new image, notice image updates in step 2, go to step 3, notice image updates in step 3, click "Create Campaign" button, notice uploaded image is used for campaign.
6. Go back to step 1, enter a new url, notice new information shows. Click "next" button. Notice new info is displayed for product. Repeat steps above.
#### Any background context you want to provide?

I removed (commented out) the check for [CreateService.cardImage](https://github.com/emotivhq/gs-concierge/compare/master...cardImg#diff-8503e4b0a5bc243afea7de7610358a56R58) because it was causing the image to remain the same if a second URL was entered.
#### What are the relevant tickets?
#40, #41
#### Before/After Screenshots (if appropriate)

N/A
#### Questions:
- **Is there a blog post?** No
- **Does the knowledge base or Wiki need an update?** No
- **Does this add new dependencies? Which ones?** No
